### PR TITLE
💥 Convert package to ESM

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Node CI
+
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        node: [12.20.0, 14.13.1, 16.0.0]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node }}
+    - name: Install dependencies
+      run: npm install
+    - name: Run tests
+      run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /node_modules/
-/npm-debug.log

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,4 @@
 /**
- * Compute the 32-bit MurmurHash3 of the supplied `key`. If the `key` is given as string it will be [encoded using the UTF8 encoding](https://github.com/LinusU/encode-utf8).
+ * Compute the 32-bit MurmurHash3 of the supplied `key`. If the `key` is given as a string it will be [encoded using the UTF8 encoding](https://github.com/LinusU/encode-utf8).
  */
-declare function murmur32 (key: ArrayBuffer | string): ArrayBuffer
-
-export = murmur32
+export default function murmur32 (key: ArrayBuffer | string): ArrayBuffer

--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
-var imul = require('imul')
-var fmix = require('fmix')
-var encodeUtf8 = require('encode-utf8')
+import encodeUtf8 from 'encode-utf8'
+import fmix from 'fmix'
 
-var C = new Uint32Array([
+const C = new Uint32Array([
   0xcc9e2d51,
   0x1b873593
 ])
@@ -12,26 +11,26 @@ function rotl (m, n) {
 }
 
 function body (key, hash) {
-  var blocks = (key.byteLength / 4) | 0
-  var view32 = new Uint32Array(key, 0, blocks)
+  const blocks = (key.byteLength / 4) | 0
+  const view32 = new Uint32Array(key, 0, blocks)
 
-  for (var i = 0; i < blocks; i++) {
-    view32[i] = imul(view32[i], C[0])
+  for (let i = 0; i < blocks; i++) {
+    view32[i] = Math.imul(view32[i], C[0])
     view32[i] = rotl(view32[i], 15)
-    view32[i] = imul(view32[i], C[1])
+    view32[i] = Math.imul(view32[i], C[1])
 
     hash[0] = (hash[0] ^ view32[i])
     hash[0] = rotl(hash[0], 13)
-    hash[0] = imul(hash[0], 5) + 0xe6546b64
+    hash[0] = Math.imul(hash[0], 5) + 0xe6546b64
   }
 }
 
 function tail (key, hash) {
-  var blocks = (key.byteLength / 4) | 0
-  var reminder = (key.byteLength % 4)
+  const blocks = (key.byteLength / 4) | 0
+  const reminder = (key.byteLength % 4)
 
-  var k = 0
-  var tail = new Uint8Array(key, blocks * 4, reminder)
+  let k = 0
+  const tail = new Uint8Array(key, blocks * 4, reminder)
   switch (reminder) {
     case 3:
       k = (k ^ (tail[2] << 16))
@@ -42,9 +41,9 @@ function tail (key, hash) {
     case 1:
       k = (k ^ (tail[0] << 0))
 
-      k = imul(k, C[0])
+      k = Math.imul(k, C[0])
       k = rotl(k, 15)
-      k = imul(k, C[1])
+      k = Math.imul(k, C[1])
       hash[0] = (hash[0] ^ k)
   }
 }
@@ -54,7 +53,7 @@ function finalize (key, hash) {
   hash[0] = fmix(hash[0])
 }
 
-module.exports = function murmur (key, seed) {
+export default function murmur (key, seed) {
   seed = (seed ? (seed | 0) : 0)
 
   if (typeof key === 'string') {
@@ -65,7 +64,7 @@ module.exports = function murmur (key, seed) {
     throw new TypeError('Expected key to be ArrayBuffer or string')
   }
 
-  var hash = new Uint32Array([seed])
+  const hash = new Uint32Array([seed])
 
   body(key, hash)
   tail(key, hash)

--- a/package.json
+++ b/package.json
@@ -3,18 +3,20 @@
   "version": "0.2.0",
   "license": "MIT",
   "repository": "LinusU/murmur-32",
+  "type": "module",
+  "exports": "./index.js",
   "scripts": {
-    "test": "standard && node test"
+    "test": "standard && node test && ts-readme-generator --check"
   },
   "dependencies": {
-    "encode-utf8": "^1.0.3",
-    "fmix": "^0.1.0",
-    "imul": "^1.0.0"
+    "encode-utf8": "^2.0.0",
+    "fmix": "^1.0.0"
   },
   "devDependencies": {
     "arraybuffer-equal": "^1.0.4",
-    "hex-to-array-buffer": "^1.1.0",
-    "standard": "^14.3.4"
+    "hex-to-array-buffer": "^2.0.0",
+    "standard": "^16.0.3",
+    "ts-readme-generator": "^0.5.1"
   },
   "keywords": [
     "digest",
@@ -26,5 +28,8 @@
     "murmurhash",
     "murmurhash3",
     "quick"
-  ]
+  ],
+  "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+  }
 }

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ npm install --save murmur-32
 ## Usage
 
 ```js
-const murmur32 = require('murmur-32')
+import murmur32 from 'murmur-32'
 
 murmur32('linus')
 //=> ArrayBuffer { 4 }
@@ -22,10 +22,12 @@ murmur32(new ArrayBuffer(10))
 
 ## API
 
-### murmur32(key: ArrayBuffer | string) => ArrayBuffer
+### `murmur32(key)`
 
-Compute the 32-bit MurmurHash3 of the supplied `key`. If the `key` is given as
-string it will be [encoded using the UTF8 encoding](https://github.com/LinusU/encode-utf8).
+- `key` (`ArrayBuffer | string`, required)
+- returns `ArrayBuffer`
+
+Compute the 32-bit MurmurHash3 of the supplied `key`. If the `key` is given as a string it will be [encoded using the UTF8 encoding](https://github.com/LinusU/encode-utf8).
 
 ## See also
 

--- a/test.js
+++ b/test.js
@@ -1,9 +1,9 @@
-var murmur = require('./')
-var assert = require('assert')
-var isEqual = require('arraybuffer-equal')
-var hexToArrayBuffer = require('hex-to-array-buffer')
+import assert from 'node:assert'
+import isEqual from 'arraybuffer-equal'
+import hexToArrayBuffer from 'hex-to-array-buffer'
+import murmur from './index.js'
 
-var testCases = [
+const testCases = [
   ['00000000', ''],
   ['13d26bba', 'test'],
   ['f72c4e83', 'linus'],


### PR DESCRIPTION
Migration Guide:

This relases changes the package from a Common JS module to an EcmaScript module, and drops support for older versions of Node.

- The minimum version of Node.js supported is now: `12.20.0`, `14.13.1`, and `16.0.0`
- The package must now be imported using the native `import` syntax instead of with `require`